### PR TITLE
set DEBIAN_FRONTEND=noninteractive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:experimental
 FROM ubuntu as cpp-build-base
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y build-essential git cmake autoconf libtool pkg-config
 RUN apt-get install -y librsvg2-dev libcairo2 libcairo2-dev libcpprest-dev cppcheck
 RUN apt-get install -y libcurl4-openssl-dev


### PR DESCRIPTION
I found when I tried to build this I got stuck at a prompt for configuring `tzdata`

```
Setting up tzdata (2019c-3ubuntu1) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
Configuring tzdata
```

`DEBIAN_FRONTEND=noninteractive` fixed this for me and is good practice for automated installs anyway.